### PR TITLE
Update `.travis.yml`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: false
 language: node_js
 node_js:
   - '0.10'
+  - '0.12'
+  - 'iojs'


### PR DESCRIPTION
To make Travis test in Node 0.12 and io.js too. Also enabled the [container-based infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/).
